### PR TITLE
Fix format_timestamp.py bug

### DIFF
--- a/ai_services/anomaly_detection/data_preprocessing_examples/oci_data_flow_based_examples/example_code/format_timestamp.py
+++ b/ai_services/anomaly_detection/data_preprocessing_examples/oci_data_flow_based_examples/example_code/format_timestamp.py
@@ -2,6 +2,7 @@ from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
 import argparse
 
+ISO_TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'"
 
 def __create_spark_session(session_name):
     """
@@ -16,20 +17,23 @@ def __create_spark_session(session_name):
 
 
 # The empty **kwargs is for generalization of the function interface
-def format_timestamp(df, **kwargs):
+def format_timestamp(df,
+    columnName="timestamp",
+    timestampFormat=ISO_TIMESTAMP_FORMAT, **kwargs):
     """
     Reformat timestamps to ISO 8601
     Args:
         df: input dataframe
+        columnName: timestamp column name
+        timestampFormat: timestamp format used
 
     Return:
         input dataframe with timestamps formatted as ISO 8601
     """
     return df.withColumn(
-        "timestamp",
+        columnName,
         F.date_format(
-            F.to_timestamp("timestamp"), "yyyy-MM-dd'T'HH:mm:ss'Z'").cast(
-            "string"
+            F.to_timestamp(columnName, timestampFormat), ISO_TIMESTAMP_FORMAT
         ),
     )
 
@@ -38,6 +42,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--input", required=True)
     parser.add_argument("--output", required=True)
+    parser.add_argument(
+        "--columnName", required=False, default="timestamp"
+    )
+    parser.add_argument(
+        "--timestampFormat", required=False, default=ISO_TIMESTAMP_FORMAT
+    )
     parser.add_argument("--coalesce", required=False, action="store_true")
     args = parser.parse_args()
 


### PR DESCRIPTION
## Testing Done

* Tested on local environment by provided a different timestamp format in the input cells.
* Verified that without this change, all the cells are having `None` date values.
* Verified that with this change, all the related cells are having appropriate timestamp though the provided timestamp is not the default format string.